### PR TITLE
Remove unused verification method

### DIFF
--- a/google5562f63703044f6d.html
+++ b/google5562f63703044f6d.html
@@ -1,1 +1,0 @@
-google-site-verification: google5562f63703044f6d.html


### PR DESCRIPTION
We no longer use this. We use the Google analytics link instead.